### PR TITLE
Update theme for MATE -> XFCE

### DIFF
--- a/themes/solus/assets/sass/elements/panel.sass
+++ b/themes/solus/assets/sass/elements/panel.sass
@@ -97,11 +97,11 @@
 .gnome
 	@include panel-colors($panel-gnome-swatch)
 
-.mate
-	@include panel-colors($panel-mate-swatch)
-
 .plasma
 	@include panel-colors($panel-plasma-swatch)
+
+.xfce
+	@include panel-colors($panel-xfce-swatch)
 
 // Specialized
 @import panels/branding

--- a/themes/solus/assets/sass/meta/colors.sass
+++ b/themes/solus/assets/sass/meta/colors.sass
@@ -20,8 +20,8 @@ $red: #ef2929
 // Desktop Swatches
 $swatch-budgie: (bg: $solus-blue, fg: $white)
 $swatch-gnome: (bg: $egyptian-blue, fg: $white)
-$swatch-mate: (bg: $lime, fg: $black)
 $swatch-plasma: (bg: $mauve, fg: $black)
+$swatch-xfce: (bg: $lime, fg: $black)
 
 // --------
 // Elements
@@ -44,8 +44,8 @@ $panel-gamers-swatch: $swatch-gray
 // --- Experiences Page ---
 $panel-budgie-swatch: $swatch-budgie
 $panel-gnome-swatch: $swatch-gnome
-$panel-mate-swatch: $swatch-mate
 $panel-plasma-swatch: $swatch-plasma
+$panel-xfce-swatch: $swatch-xfce
 // --- Specialized ---
 $panel-branding-swatch: $swatch-light-gray
 $panel-podcast-swatch: $swatch-marble

--- a/themes/solus/data/experience/mate.yaml
+++ b/themes/solus/data/experience/mate.yaml
@@ -1,9 +1,0 @@
-image: "/release-images/LATEST_RELEASE/MATE.jpg"
-header: MATE
-description : A traditional desktop for advanced users and older hardware. 
-differentiators:
-  Brisk:
-    header: A modern menu for the MATE Desktop
-    description: |-
-        We ship MATE with the Brisk Menu, a menu that strikes a balance between preserving the traditional feel of MATE and an efficient and modern design.
-        Brisk Menu enables quick access to your applications, the Software Center, and your settings!

--- a/themes/solus/data/experience/xfce.yaml
+++ b/themes/solus/data/experience/xfce.yaml
@@ -1,0 +1,8 @@
+image: "/release-images/LATEST_RELEASE/XFCE.jpg"
+header: XFCE
+description : A lightweight desktop that aims to be fast while still being friendly. 
+differentiators:
+  Fast:
+    header: Light on its feet
+    description: |-
+      We ship the XFCE Desktop to provide a full-featured experience for users running less powerful hardware.

--- a/themes/solus/data/technologies/nonsolus.yaml
+++ b/themes/solus/data/technologies/nonsolus.yaml
@@ -13,9 +13,9 @@ GNU_Project:
 Linux:
     description: The Linux kernel is the absolute heart of the operating system, providing an environment for all user-land programs to operate, hardware support, networking, etc.
     url: https://www.kernel.org/
-MATE_Desktop_Environment:
-    description: The MATE Desktop is a continuation of the GNOME 2 Desktop code base and paradigm, providing a more traditional desktop metaphor for our Solus MATE users.
-    url: https://mate-desktop.org/
+XFCE_Desktop_Environment:
+    description: The XFCE Desktop Environment aims to be fast even on systems with lower powered hardware, while staying modern and friendly.
+    url: https://xfce.org/
 XOrg_project:
     description: The X.Org display server forms the backbone of all desktop experiences on Solus, enabling input device support and the ability to render on screen.
     url: https://www.x.org/wiki/

--- a/themes/solus/data/technologies/solus.yaml
+++ b/themes/solus/data/technologies/solus.yaml
@@ -1,7 +1,3 @@
-Brisk_Menu:
-    description: An efficient menu for the MATE Desktop
-    type: desktop
-    url: https://github.com/getsolus/brisk-menu
 DoFlicky:
     description: Simplistic driver detection and management utility specifically for Solus.
     type: desktop
@@ -18,10 +14,6 @@ Linux_Steam_Integration:
     description: Helper for enabling better Steam integration on Linux.
     type: desktop
     url: https://github.com/getsolus/linux-steam-integration
-MATE_Notification_Theme_Slate:
-    description: A MATE Notification theme, emulating the Arc-styled Budgie notifications of Solus.
-    type: desktop
-    url: https://github.com/getsolus/mate-notification-theme-slate
 Solus_Software_Center:
     description: Software Center of Solus.
     type: desktop

--- a/themes/solus/layouts/shortcodes/pages/download.html
+++ b/themes/solus/layouts/shortcodes/pages/download.html
@@ -1,6 +1,6 @@
 {{ $site := .Site }}
 <div class="downloads">
-{{ range $edition := (slice "Budgie" "GNOME" "MATE" "Plasma") }}
+{{ range $edition := (slice "Budgie" "GNOME" "Plasma" "XFCE") }}
 	{{ $editionInfo := (index $site.Data.isos.info $edition )}}
 	{{ $release := printf "Solus-%s-%s" $site.Data.isos.info.Version $edition }}
 	{{ $editionISO := printf "%s.iso" $release }}

--- a/themes/solus/layouts/shortcodes/panels/designed-for-everyone.html
+++ b/themes/solus/layouts/shortcodes/panels/designed-for-everyone.html
@@ -2,12 +2,12 @@
 	<section>
 		<h1>Designed for Everyone</h1>
 		<p>Solus provides a multitude of experiences that enable you to get the most out of your hardware.</p>
-		<p>From our flagship Budgie experience for modern devices to the more traditional MATE experience for lower-end devices, Solus aims to provide the best experience for your device.</p>
+		<p>From our flagship Budgie experience for modern devices to the more traditional XFCE experience for lower-end devices, Solus aims to provide the best experience for your device.</p>
 		<div class="menu">
             <nav>
 			    <a class="button" href="/solus/experiences">Learn More</a>
             </nav>
 		</div>
 	</section>
-	<img alt="Representation of MATE" src="{{ .Site.BaseURL }}/imgs/panels/mate-representation.jpg" />
+	<img alt="XFCE Desktop screenshot" src="{{ .Site.BaseURL }}/imgs/release-images/4.5/XFCE.jpg" />
 </div>

--- a/themes/solus/layouts/shortcodes/panels/solus.html
+++ b/themes/solus/layouts/shortcodes/panels/solus.html
@@ -1,6 +1,6 @@
 {{ $title := .Page.Title }}
 <div class="panel row solus">
- 	<img alt="Laptop" src="{{ .Site.BaseURL }}/imgs/panels/solus/laptop.png" />
+ 	<img alt="Laptop graphic with Budge Desktop screenshot on screen" src="{{ .Site.BaseURL }}/imgs/panels/solus/laptop-budgie.png" />
 	<section class="center">
 		<h1>Solus</h1>
 		<p>


### PR DESCRIPTION
- Remove MATE from "Download" and "Experience" pages, add XFCE
- Remove MATE and MATE related entries from "Technologies"
- Add XFCE Desktop as a non-solus technology
- Update the homeppage banners to use new images:
  - Update the laptop graphic with a new budgie screenshot
  - Change the "MATE representation" image to the 4.5 MATTE release image
  - Note that these changes do not include the image files; those would be supplied by the "parent" repo. My reasoning is that this allows the images to be updated without updating the theme and then pulling _that_ update into the parent repo