### PR TITLE
Fix PublishDate parameter

### DIFF
--- a/themes/solus/layouts/partials/meta.html
+++ b/themes/solus/layouts/partials/meta.html
@@ -46,8 +46,8 @@
 {{ end }}
 <!-- End of Blog Post Specific Content -->
 
-{{ if isset . "PublishedDate" }}
-	<meta name="article:published_time" content="{{ .PublishedDate }}" />
+{{ if isset .Params "publishdate" }}
+	<meta name="article:published_time" content="{{ .Params.PublishDate }}" />
 {{ end }}
 
 {{ $generalMetaTags := "solus, linux, operating system, budgie, mate" }}


### PR DESCRIPTION
Also rename from PublishedDate, as PublishDate seems to be the default

This fixes a warning on (re)building Solus site

`WARN  calling IsSet with unsupported type "ptr" (*hugolib.pageState) will always return false.`

I *think* this is what this statement was supposed to accomplish, but I'm not 100% sure, so this is a separate PR from the deprecation fix. There's no PublishedDate (or now PublishDate) set for anything at the moment either way, as far as I can tell. When I set one for a random blog post it gets applied just fine with this PR.